### PR TITLE
 Make sure we don't undefine needed methods

### DIFF
--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -5,7 +5,7 @@ module Liquid
   #
   # One of the strainer's responsibilities is to keep malicious method calls out 
   class Strainer
-    @@required_methods = ["__send__", "__id__", "respond_to?", "extend", "methods"]
+    @@required_methods = ["__send__", "__id__", "object_id", "respond_to?", "extend", "methods"]
     
     @@filters = []
     

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -5,7 +5,7 @@ module Liquid
   #
   # One of the strainer's responsibilities is to keep malicious method calls out 
   class Strainer
-    @@required_methods = ["__send__", "__id__", "object_id", "respond_to?", "extend", "methods"]
+    @@required_methods = [:__send__, :__id__, :object_id, :respond_to?, :extend, :methods]
     
     @@filters = []
     


### PR DESCRIPTION
Ruby really doesn't like it:

```
/Users/jakob/Projects/OpenSource/comatose/lib/liquid/strainer.rb:38: warning: undefining `__send__' may cause serious problems
/Users/jakob/Projects/OpenSource/comatose/lib/liquid/strainer.rb:38: warning: undefining `object_id' may cause serious problems
```